### PR TITLE
Fixed sendable warning

### DIFF
--- a/Sources/InteractiveMap/MapParser.swift
+++ b/Sources/InteractiveMap/MapParser.swift
@@ -215,7 +215,7 @@ public class MapParser : NSObject, XMLParserDelegate {
     }
 }
 
-public struct PathExecutionCommand : CustomStringConvertible, Identifiable {
+public struct PathExecutionCommand : CustomStringConvertible, Identifiable, Sendable {
     public var id = UUID()
     var coordinate: CGPoint // (x, y)
     var command : String

--- a/Sources/InteractiveMap/MapUtils.swift
+++ b/Sources/InteractiveMap/MapUtils.swift
@@ -141,7 +141,7 @@ func executeCommand(svgData: PathData, rect: CGRect) -> Path {
 ///
 ///
 @available(iOS 13.0, macOS 10.15, *)
-public struct PathData : Identifiable {
+public struct PathData : Identifiable, Sendable {
     public var id : String = ""
     public var name: String = ""
     public var boundingBox: CGRect? = nil


### PR DESCRIPTION
PathData and PathExectionCommand are sendable because they are value types contain other value types, but need to be marked Sendable to remove the build warning.